### PR TITLE
feat(install): add automated install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ Clone the repository
 laravel new my-app --using=jeffersongoncalves/filakit --database=mysql
 ```
 
+###  Easy Installation
+
+FilaKit can be easily installed using the following command:
+
+```bash
+php install.php
+```
+
+This command automates the installation process by:
+- Installing Composer dependencies
+- Setting up the environment file
+- Generating application key
+- Setting up the database
+- Running migrations
+- Installing Node.js dependencies
+- Configuring Herd (if used)
+
+### Manual Installation
+
 Install JavaScript dependencies
 ``` bash
 pnpm install

--- a/install.php
+++ b/install.php
@@ -1,0 +1,188 @@
+#!/usr/bin/env php
+<?php
+
+class LaravelInstaller
+{
+    private string $packageManager;
+    private array $validPackageManagers = ['npm', 'pnpm', 'bun', 'yarn'];
+    private string $basePath;
+
+    public function __construct(string $basePath = __DIR__)
+    {
+        $this->basePath = $basePath;
+    }
+
+    /**
+     * Run the installation process
+     */
+    public function install(): void
+    {
+        $this->displayHeader();
+
+        // Initialize the package manager if needed
+        if (!is_dir('node_modules')) {
+            $this->setupPackageManager();
+        }
+
+        // Install dependencies
+        $this->installComposerDependencies();
+        $this->setupEnvironmentFile();
+        $this->generateAppKey();
+        $this->setupDatabase();
+        $this->runMigrations();
+        $this->installNodeDependencies();
+
+        // Configure Herd if used
+        $this->configureHerd();
+
+        $this->displayCompletionMessage();
+    }
+
+    private function displayHeader(): void
+    {
+        echo "Laravel Project Installer\n";
+        echo "-------------------------\n";
+    }
+
+    /**
+     * Set up a package manager based on user selection
+     */
+    private function setupPackageManager(): void
+    {
+        $this->packageManager = $this->ask(
+            'Select a package manager [' . implode(', ', $this->validPackageManagers) . ']',
+            'npm'
+        );
+
+        if (!in_array($this->packageManager, $this->validPackageManagers)) {
+            $this->exitWithError("Invalid package manager selected.");
+        }
+    }
+
+    private function installComposerDependencies(): void
+    {
+        if (!is_dir('vendor')) {
+            $this->runCommand('composer install --no-interaction --ignore-platform-reqs');
+        } else {
+            $this->logInfo("Vendor directory already exists. Skipping composer install.");
+        }
+    }
+
+    private function setupEnvironmentFile(): void
+    {
+        if (!file_exists('.env')) {
+            $this->logInfo("Creating .env file...");
+            if (!copy('.env.example', '.env')) {
+                $this->exitWithError("Failed to create .env file.");
+            }
+        } else {
+            $this->logInfo(".env file already exists. Skipping copy.");
+        }
+    }
+
+    private function generateAppKey(): void
+    {
+        $this->runCommand('php artisan key:generate');
+    }
+
+    private function setupDatabase(): void
+    {
+        $dbPath = $this->basePath . '/database/database.sqlite';
+        $this->ensureDatabaseFile($dbPath);
+    }
+
+    private function runMigrations(): void
+    {
+        $this->runCommand('php artisan migrate');
+    }
+
+    private function installNodeDependencies(): void
+    {
+        if (!is_dir('node_modules')) {
+            $this->runCommand("{$this->packageManager} install");
+        } else {
+            $this->logInfo("Node modules already installed. Skipping {$this->packageManager} install.");
+        }
+    }
+
+    private function configureHerd(): void
+    {
+        $usingHerd = $this->confirm('Are you using Herd?');
+
+        if ($usingHerd) {
+            $this->logInfo("Herd detected. Running herd link...");
+            $this->runCommand('herd link');
+
+            $secureSite = $this->confirm('Do you want to secure the site with HTTPS?');
+            if ($secureSite) {
+                $this->logInfo("Securing site with HTTPS...");
+                $this->runCommand('herd secure');
+            }
+        }
+    }
+
+    private function displayCompletionMessage(): void
+    {
+        echo "\n✅ Installation complete!\n";
+    }
+
+    private function ensureDatabaseFile(string $path): void
+    {
+        if (!file_exists($path)) {
+            $this->logInfo("Creating database file at: $path");
+
+            if (!is_dir(dirname($path))) {
+                if (!mkdir(dirname($path), 0755, true)) {
+                    $this->exitWithError("Failed to create directory: " . dirname($path));
+                }
+            }
+
+            if (!touch($path)) {
+                $this->exitWithError("Failed to create database file: $path");
+            }
+        } else {
+            $this->logInfo("Database file already exists: $path");
+        }
+    }
+
+    private function ask(string $question, string $default = ''): string
+    {
+        $prompt = $question . ($default ? " ({$default})" : '') . ': ';
+        $answer = readline($prompt);
+        return $answer ?: $default;
+    }
+
+    private function confirm(string $question, bool $default = false): bool
+    {
+        $answer = $this->ask($question . ' [' . ($default ? 'Y/n' : 'y/N') . ']');
+        return $answer ? strtolower($answer[0]) === 'y' : $default;
+    }
+
+    private function runCommand(string $command): void
+    {
+        $this->logInfo("Running: $command");
+        passthru($command, $exitCode);
+
+        if ($exitCode !== 0) {
+            $this->exitWithError("Command failed: $command", $exitCode);
+        }
+    }
+
+    private function logInfo(string $message): void
+    {
+        echo "$message\n";
+    }
+
+    private function exitWithError(string $message, int $code = 1): void
+    {
+        echo "ERROR: $message\n";
+        exit($code);
+    }
+
+    private function isWindows(): bool
+    {
+        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+    }
+}
+
+(new LaravelInstaller())->install();

--- a/install.php
+++ b/install.php
@@ -30,6 +30,7 @@ class LaravelInstaller
         $this->generateAppKey();
         $this->setupDatabase();
         $this->runMigrations();
+        $this->runSeeders();
         $this->installNodeDependencies();
 
         // Configure Herd if used
@@ -94,6 +95,15 @@ class LaravelInstaller
     private function runMigrations(): void
     {
         $this->runCommand('php artisan migrate');
+    }
+
+    private function runSeeders(): void
+    {
+        if ($this->confirm('Do you want to run the seeders?')) {
+            $this->runCommand('php artisan db:seed');
+        } else {
+            $this->logInfo("Skipping database seeding.");
+        }
     }
 
     private function installNodeDependencies(): void


### PR DESCRIPTION
This pull request introduces an automated installation process for the FilaKit Laravel project, simplifying setup for users. Key changes include the addition of an `install.php` script and corresponding updates to the `README.md` file to document the new installation options.

### Documentation Updates:
* Added an "Easy Installation" section in `README.md` to describe the new automated installation process using `install.php`. It outlines the steps performed by the script, such as installing dependencies, setting up the environment, and configuring Herd.

### New Installation Script:
* Introduced the `install.php` script, which automates the following tasks:
  - Installing Composer and Node.js dependencies.
  - Setting up the `.env` file and generating the application key.
  - Creating and configuring the SQLite database.
  - Running database migrations.
  - Optionally configuring Herd for HTTPS setup.